### PR TITLE
Add require files to spec_helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,6 @@
 require 'simplecov'
 SimpleCov.start
+require 'Date'
+require 'pry'
+require './lib/enigma'
+require './lib/offset'


### PR DESCRIPTION
Added all files to spec_helper so to only require this file in spec_files as I anticipate all lib files will be required for each spec file.