### PR TITLE
Require spec helper in spec file

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,11 @@
 require 'simplecov'
 SimpleCov.start
+# run 'rspec spec/spec_helper.rb' to run simplecov
+# open coverage/index.html (in Terminal)
+
 require 'Date'
-require 'pry'
+require_relative 'enigma_spec'
+require_relative 'offset_spec'
 require './lib/enigma'
 require './lib/offset'
+require 'pry'


### PR DESCRIPTION
Spec files lost. Reformat to require relative