### PR TITLE
Require relative spec helper

### DIFF
--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -1,5 +1,4 @@
-require 'Date'
-require './lib/enigma'
+require_relative 'spec_helper'
 
 RSpec.describe Enigma do
   it 'exists' do


### PR DESCRIPTION
Only require spec helper in top of spec file