### PR TITLE
Top down

### DIFF
--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -1,4 +1,7 @@
 require_relative 'spec_helper'
+require 'Date'
+require './lib/enigma'
+require './lib/offset'
 
 RSpec.describe Enigma do
   it 'exists' do


### PR DESCRIPTION
Spec helper can only require relative